### PR TITLE
add a ci workflow with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,84 @@
+on: [push]
+
+name: ci
+
+jobs:
+  build:
+    name: Build + Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Cache rustup toolchains
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.rustup/settings.toml
+            ~/.rustup/toolchains/*
+            ~/.rustup/update-hashes/*
+          key: ${{ runner.os }}-rust-toolchain
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install the stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Build
+        run: cargo build
+
+      - name: Run tests
+        run: cargo test
+  lints:
+    name: Lints
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Cache rustup toolchains
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.rustup/settings.toml
+            ~/.rustup/toolchains/*
+            ~/.rustup/update-hashes/*
+          key: ${{ runner.os }}-rust-toolchain
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install the stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Install the nightly toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          components: rustfmt
+
+      - name: cargo fmt
+        run: cargo +nightly fmt --all -- --check
+
+      - name: cargo clippy
+        run: cargo clippy -- -D warnings

--- a/src/surfaces.rs
+++ b/src/surfaces.rs
@@ -66,7 +66,11 @@ mod tests {
 
     #[test]
     fn sphere_bounding_box() {
-        let sphere = Sphere::new(Point3::at(0., 0., 0.), 1.0, Material::lambertian(Vec3::new(1.0, 1.0, 1.0)));
+        let sphere = Sphere::new(
+            Point3::at(0., 0., 0.),
+            1.0,
+            Material::lambertian(Vec3::new(1.0, 1.0, 1.0)),
+        );
         let aabb = sphere.bounding_box();
 
         assert_eq!(aabb.min().get(0), -1.0);

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,8 +1,4 @@
-use std::cmp::{
-    // Eq,
-    // Ord,
-    Ordering,
-};
+use std::cmp::Ordering;
 
 use rand::distributions::Uniform;
 use rand::Rng;


### PR DESCRIPTION
The worflow does the following:
- Build the project and run tests
- Check for necessary cargo fmt (nightly)
- Check for cargo clippy warnings

The toolchains and dependencies are cached to save build time (~30s).